### PR TITLE
Update SpeakEasy.h

### DIFF
--- a/base/SpeakEasy.h
+++ b/base/SpeakEasy.h
@@ -83,6 +83,7 @@ unsigned long tmr_fast=0, tmr_slow=0;
 #define	SLOW_halfday()	if (!(phase_slow % 4321))
 #define	SLOW_1day()		if (!(phase_slow % 8641))
 
+#define EXECUTESPEEDY   else
 #define UPDATESPEEDY()	phase_speedy = (phase_speedy + 1) % num_phases
 #define	SPEEDY_x(n)		if (!(phase_speedy % n))
 

--- a/base/SpeakEasy.h
+++ b/base/SpeakEasy.h
@@ -83,7 +83,7 @@ unsigned long tmr_fast=0, tmr_slow=0;
 #define	SLOW_halfday()	if (!(phase_slow % 4321))
 #define	SLOW_1day()		if (!(phase_slow % 8641))
 
-#define EXECUTESPEEDY   else
+#define EXECUTESPEEDY() else
 #define UPDATESPEEDY()	phase_speedy = (phase_speedy + 1) % num_phases
 #define	SPEEDY_x(n)		if (!(phase_speedy % n))
 


### PR DESCRIPTION
Reviewing the "examples\ethernet\e03_AnalogInput.ino" example I encountered an "else" no "if" prior.
Seeking "SpeakEasy.h" I have seen that is not a bug, but I think people who start with Souliss may have trouble knowing that a "else" is needed before "UPDATESPEEDY".
I propose to add a "#define EXECUTESPEEDY()" to "SpeakEasy.h"
This would give uniformity to the programming and avoid a cause of errors.

The order for programming is:
EXECUTEFAST()      { --code-- }
EXECUTESLOW()     { --code-- }  (only if required)
EXECUTESPEEDY() { --code-- } (only if required)
